### PR TITLE
Fix castopod using sentinel

### DIFF
--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: castopod
 description: Helm chart for Castopod - free and open-source hosting platform for podcasters.
 type: application
-version: 0.2.4
-appVersion: "1.12.4"
+version: 1.11.0
+appVersion: "1.11.0"
 keywords:
   - castopod
   - storage

--- a/charts/castopod/README.md
+++ b/charts/castopod/README.md
@@ -1,6 +1,6 @@
 # castopod
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.0](https://img.shields.io/badge/AppVersion-1.11.0-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.4](https://img.shields.io/badge/AppVersion-1.12.4-informational?style=flat-square)
 
 Helm chart for Castopod - free and open-source hosting platform for podcasters.
 

--- a/charts/castopod/templates/deployment.yaml
+++ b/charts/castopod/templates/deployment.yaml
@@ -66,12 +66,12 @@ spec:
             - name: CP_DISABLE_HTTPS
               value: "1"
             {{- end }}
-            {{- if (eq .Values.redis.architecture "standalone") }}
+            {{- if not .Values.redis.sentinel.enabled }}
             - name: CP_REDIS_HOST
               value: {{ .Release.Name }}-redis-master
-            {{- else if (eq .Values.redis.architecture "replication") }}
+            {{- else }}
             - name: CP_REDIS_HOST
-              value: {{ .Release.Name }}-redis
+              value: {{ .Release.Name }}-redis #Sentinel doesn't work, actually
             {{- end }}
             - name: CP_REDIS_PASSWORD
               valueFrom:

--- a/charts/castopod/values.yaml
+++ b/charts/castopod/values.yaml
@@ -157,7 +157,7 @@ mariadb:
       size: 8Gi
 
 redis:
-  enabled: true
+  enabled: true # -- Do NOT enable sentinel, castopod doesn't support it
   architecture: replication # -- Or standalone, turn off sentinel for not HA solution
   global:
     imagePullSecrets: []
@@ -167,15 +167,7 @@ redis:
       size: 8Gi
   auth:
     enabled: true
-    sentinel: true
     existingSecret: castopod # -- Must be equal to secrets.name
     existingSecretPasswordKey: "redis-password"
     usePasswordFiles: false
     usePasswordFileFromSecret: false
-  sentinel:
-    enabled: true
-    quorum: 3
-    masterSet: castopodmaster
-    persistence:
-      enabled: false
-      storageclass: ""


### PR DESCRIPTION
Castopod doesn't support sentinel, therefore it uses any service for write operations, even on read-only replicas. Fix is simple: remove sentinel from helm-chart. Also naming of the appversions will be similar to docker image versions